### PR TITLE
Add calculate_bars for Visualizing Timing Data

### DIFF
--- a/examples/bench/app/dev/benches/sorted_bench.rb
+++ b/examples/bench/app/dev/benches/sorted_bench.rb
@@ -1,7 +1,7 @@
 class SortedBench < DevSystem::Bench
   # https://rubyapi.org/3.1/o/benchmark
   require "benchmark"
-  
+
   def self.call env
     super
     t = Time.now
@@ -34,9 +34,12 @@ class SortedBench < DevSystem::Bench
 
     sorted = marks.sort_by { |_k, tms| tms.total }.to_h
 
+    bars_lengths = calculate_bars(sorted)
+    bars   = bars_lengths.map { "■" * _1 }
+
     sorted.each.with_index do |(label, tms), i|
       tms = tms.format "%10.6u     %10.6y         %10.6t"
-      s = "[#{i.next.to_s.rjust_zeroes 2}/#{marks.count.to_s.rjust_zeroes 2}]      #{label.rjust_blanks length}   #{tms}"
+      s = "[#{i.next.to_s.rjust_zeroes 2}/#{marks.count.to_s.rjust_zeroes 2}]      #{label.rjust_blanks length}   #{tms}  #{bars[i]}"
 
       s = (stick s, :light_green).to_s if i == 0
       s = (stick s, :light_red  ).to_s if i == marks.count-1
@@ -68,5 +71,32 @@ class SortedBench < DevSystem::Bench
   def self.marks()= @marks ||= {}
 
   def self.mark(label, &block)= marks[label] = block
+
+  #
+
+  def self.calculate_bars(sorted, max_bar_size = 20)
+    times    = sorted.values.map(&:total)
+    min_time = times.min
+    max_time = times.max
+    range    = max_time - min_time
+
+    lengths = if times.size <= 3
+      times.map do |time|
+        proportion = time / max_time.to_f
+        bar_length = (proportion * max_bar_size).round
+        bar_length = 1 if bar_length.zero? && time > 0
+        bar_length
+      end
+    else
+      times.map do |time|
+        proportion = range.zero? ? 1.0 : (time - min_time) / range.to_f
+        bar_length = (proportion * max_bar_size).round
+
+        bar_length
+      end
+    end
+
+    lengths
+  end
 
 end


### PR DESCRIPTION
This PR introduces the calculate_bars function to generate visual bar lengths based on timing metrics. Previously, this functionality was not available. Now, the method:

1.  Computes the range (max - min) once.

2. Applies two normalization strategies:
  - For 3 or fewer items, it normalizes relative to the maximum time and ensures a minimum bar length of 1 for positive values.
  - For more than 3 items, it normalizes based on the difference from the minimum time for proportional distribution.