### PR TITLE
fix: use time_diff instead of Time lib diff

### DIFF
--- a/examples/bench/app/dev/benches/sorted_bench.rb
+++ b/examples/bench/app/dev/benches/sorted_bench.rb
@@ -47,7 +47,7 @@ class SortedBench < DevSystem::Bench
     end
     puts
   ensure
-    log "#{Lizarb.time_diff t}s | #{marks.count} marks | #{repetitions} repetitions"
+    log "#{time_diff t}s | #{marks.count} marks | #{repetitions} repetitions"
   end
 
   #

--- a/examples/bench/app/dev/benches/sorted_bench.rb
+++ b/examples/bench/app/dev/benches/sorted_bench.rb
@@ -47,7 +47,7 @@ class SortedBench < DevSystem::Bench
     end
     puts
   ensure
-    log "#{t.diff}s | #{marks.count} marks | #{repetitions} repetitions"
+    log "#{Lizarb.time_diff t}s | #{marks.count} marks | #{repetitions} repetitions"
   end
 
   #

--- a/examples/client/app/net/clients/news_client.rb
+++ b/examples/client/app/net/clients/news_client.rb
@@ -19,7 +19,7 @@ class NewsClient < NetSystem::Client
     log "rss channel title: #{ hash.dig :rss, :channel, :title }"
     hash
   ensure
-    log "#{t.diff}s to request #{url}"
+    log "#{Lizarb.time_diff t}s to request #{url}"
     hash
   end
 

--- a/examples/client/app/net/clients/news_client.rb
+++ b/examples/client/app/net/clients/news_client.rb
@@ -19,7 +19,7 @@ class NewsClient < NetSystem::Client
     log "rss channel title: #{ hash.dig :rss, :channel, :title }"
     hash
   ensure
-    log "#{Lizarb.time_diff t}s to request #{url}"
+    log "#{time_diff t}s to request #{url}"
     hash
   end
 

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -9,7 +9,7 @@ class App
 
   # called from exe/lizarb
   def self.call argv
-    log "#{$boot_time.diff}s to boot #{full_name}" if defined? $log_boot_low
+    log "#{Lizarb.time_diff $boot_time}s to boot #{full_name}" if defined? $log_boot_low
 
     should_log = log_level >= 4
     puts if should_log

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -9,7 +9,7 @@ class App
 
   # called from exe/lizarb
   def self.call argv
-    log "#{Liza::Unit.time_diff $boot_time}s to boot #{full_name}" if defined? $log_boot_low
+    log "#{$boot_time.diff}s to boot #{full_name}" if defined? $log_boot_low
 
     should_log = log_level >= 4
     puts if should_log

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -9,7 +9,7 @@ class App
 
   # called from exe/lizarb
   def self.call argv
-    log "#{$boot_time.diff}s to boot #{full_name}" if defined? $log_boot_low
+    log "#{Liza::Unit.time_diff $boot_time}s to boot #{full_name}" if defined? $log_boot_low
 
     should_log = log_level >= 4
     puts if should_log

--- a/lib/art_system/commands/chatgpt_command.rb
+++ b/lib/art_system/commands/chatgpt_command.rb
@@ -12,7 +12,7 @@ class ArtSystem::ChatgptCommand < DevSystem::SimpleCommand
 
   def after
     super
-    log "#{ Lizarb.time_diff @t }s | done"
+    log "#{ time_diff @t }s | done"
   end
 
   section :actions

--- a/lib/art_system/commands/chatgpt_command.rb
+++ b/lib/art_system/commands/chatgpt_command.rb
@@ -12,7 +12,7 @@ class ArtSystem::ChatgptCommand < DevSystem::SimpleCommand
 
   def after
     super
-    log "#{ @t.diff }s | done"
+    log "#{ Lizarb.time_diff @t }s | done"
   end
 
   section :actions

--- a/lib/dev_system/commands/test_command.rb
+++ b/lib/dev_system/commands/test_command.rb
@@ -30,7 +30,7 @@ class DevSystem::TestCommand < DevSystem::SimpleCommand
     test_classes = app_shell.get_lists.flatten
     log "Testing #{test_classes}"
     _call_testing test_classes if should_run
-    log "Done Testing (#{Lizarb.time_diff now}s)"
+    log "Done Testing (#{time_diff now}s)"
 
     unsilence!
 
@@ -38,7 +38,7 @@ class DevSystem::TestCommand < DevSystem::SimpleCommand
 
     log "Counting #{test_classes.count} Test Classes"
     _call_counting app_shell
-    log "Done Counting (#{Lizarb.time_diff now}s)"
+    log "Done Counting (#{time_diff now}s)"
   end
 
   def silence!

--- a/lib/dev_system/commands/test_command.rb
+++ b/lib/dev_system/commands/test_command.rb
@@ -30,7 +30,7 @@ class DevSystem::TestCommand < DevSystem::SimpleCommand
     test_classes = app_shell.get_lists.flatten
     log "Testing #{test_classes}"
     _call_testing test_classes if should_run
-    log "Done Testing (#{now.diff}s)"
+    log "Done Testing (#{Lizarb.time_diff now}s)"
 
     unsilence!
 
@@ -38,7 +38,7 @@ class DevSystem::TestCommand < DevSystem::SimpleCommand
 
     log "Counting #{test_classes.count} Test Classes"
     _call_counting app_shell
-    log "Done Counting (#{now.diff}s)"
+    log "Done Counting (#{Lizarb.time_diff now}s)"
   end
 
   def silence!

--- a/lib/dev_system/shells/kernel_shell.rb
+++ b/lib/dev_system/shells/kernel_shell.rb
@@ -7,7 +7,7 @@ class DevSystem::KernelShell < DevSystem::Shell
     log log_level, "#{stick command, DevSystem.color} | returns a string | executing..."
     result = Kernel.send :`, command
   ensure
-    log log_level, "#{Lizarb.time_diff t}s | executed with an output of #{"#{result.size} bytes" if result}#{result.inspect unless result} |"
+    log log_level, "#{time_diff t}s | executed with an output of #{"#{result.size} bytes" if result}#{result.inspect unless result} |"
     puts result if log? log_level
   end
 
@@ -20,7 +20,7 @@ class DevSystem::KernelShell < DevSystem::Shell
     success
   ensure
     message = success ? (stick :green, "successfully") : (stick :red, "failed")
-    log log_level, "#{Lizarb.time_diff t}s | #{message}"
+    log log_level, "#{time_diff t}s | #{message}"
   end
 
 end

--- a/lib/dev_system/shells/kernel_shell.rb
+++ b/lib/dev_system/shells/kernel_shell.rb
@@ -7,7 +7,7 @@ class DevSystem::KernelShell < DevSystem::Shell
     log log_level, "#{stick command, DevSystem.color} | returns a string | executing..."
     result = Kernel.send :`, command
   ensure
-    log log_level, "#{t.diff}s | executed with an output of #{"#{result.size} bytes" if result}#{result.inspect unless result} |"
+    log log_level, "#{Lizarb.time_diff t}s | executed with an output of #{"#{result.size} bytes" if result}#{result.inspect unless result} |"
     puts result if log? log_level
   end
 
@@ -20,7 +20,7 @@ class DevSystem::KernelShell < DevSystem::Shell
     success
   ensure
     message = success ? (stick :green, "successfully") : (stick :red, "failed")
-    log log_level, "#{t.diff}s | #{message}"
+    log log_level, "#{Lizarb.time_diff t}s | #{message}"
   end
 
 end

--- a/lib/dev_system/subsystems/generator/generators/new_generator.rb.script.erb
+++ b/lib/dev_system/subsystems/generator/generators/new_generator.rb.script.erb
@@ -23,7 +23,7 @@ DevBox.command ["shell"]
 
 require "lizarb"
 Lizarb.init_script_independent! :dev, pwd: __dir__
-puts "#{Lizarb.time_diff $boot_time}s to boot" if $log_boot_high
+puts "#{time_diff $boot_time}s to boot" if $log_boot_high
 
 # YOUR CODE HERE
 

--- a/lib/dev_system/subsystems/generator/generators/new_generator.rb.script.erb
+++ b/lib/dev_system/subsystems/generator/generators/new_generator.rb.script.erb
@@ -23,7 +23,7 @@ DevBox.command ["shell"]
 
 require "lizarb"
 Lizarb.init_script_independent! :dev, pwd: __dir__
-puts "#{Liza::Unit.time_diff $boot_time}s to boot" if $log_boot_high
+puts "#{$boot_time.diff}s to boot" if $log_boot_high
 
 # YOUR CODE HERE
 

--- a/lib/dev_system/subsystems/generator/generators/new_generator.rb.script.erb
+++ b/lib/dev_system/subsystems/generator/generators/new_generator.rb.script.erb
@@ -23,7 +23,7 @@ DevBox.command ["shell"]
 
 require "lizarb"
 Lizarb.init_script_independent! :dev, pwd: __dir__
-puts "#{$boot_time.diff}s to boot" if $log_boot_high
+puts "#{Liza::Unit.time_diff $boot_time}s to boot" if $log_boot_high
 
 # YOUR CODE HERE
 

--- a/lib/dev_system/subsystems/generator/generators/new_generator.rb.script.erb
+++ b/lib/dev_system/subsystems/generator/generators/new_generator.rb.script.erb
@@ -23,7 +23,7 @@ DevBox.command ["shell"]
 
 require "lizarb"
 Lizarb.init_script_independent! :dev, pwd: __dir__
-puts "#{$boot_time.diff}s to boot" if $log_boot_high
+puts "#{Lizarb.time_diff $boot_time}s to boot" if $log_boot_high
 
 # YOUR CODE HERE
 

--- a/lib/lab_system/clients/lab_kroki_client.rb
+++ b/lib/lab_system/clients/lab_kroki_client.rb
@@ -62,7 +62,7 @@ class LabSystem::LabKrokiClient < NetSystem::Client
 
     @result
   ensure
-    log "#{Lizarb.time_diff t}s to render #{action.inspect}"
+    log "#{time_diff t}s to render #{action.inspect}"
     @result
   end
 
@@ -117,7 +117,7 @@ class LabSystem::LabKrokiClient < NetSystem::Client
       raise "Error calling Kroki API. HTTP Status Code: #{@response.code}"
     end
   ensure
-    log "#{Lizarb.time_diff t}s to request #{request_uri}"
+    log "#{time_diff t}s to request #{request_uri}"
   end
 
 end

--- a/lib/lab_system/clients/lab_kroki_client.rb
+++ b/lib/lab_system/clients/lab_kroki_client.rb
@@ -62,7 +62,7 @@ class LabSystem::LabKrokiClient < NetSystem::Client
 
     @result
   ensure
-    log "#{t.diff}s to render #{action.inspect}"
+    log "#{Lizarb.time_diff t}s to render #{action.inspect}"
     @result
   end
 
@@ -117,7 +117,7 @@ class LabSystem::LabKrokiClient < NetSystem::Client
       raise "Error calling Kroki API. HTTP Status Code: #{@response.code}"
     end
   ensure
-    log "#{t.diff}s to request #{request_uri}"
+    log "#{Lizarb.time_diff t}s to request #{request_uri}"
   end
 
 end

--- a/lib/lab_system/commands/docker_command.rb
+++ b/lib/lab_system/commands/docker_command.rb
@@ -22,7 +22,7 @@ class LabSystem::DockerCommand < DevSystem::SimpleCommand
 
     DockerShell.hello_alpine
   ensure
-    log "#{t.diff} | done"
+    log "#{Lizarb.time_diff t} | done"
   end
 
   # liza docker:version

--- a/lib/lab_system/commands/docker_command.rb
+++ b/lib/lab_system/commands/docker_command.rb
@@ -22,7 +22,7 @@ class LabSystem::DockerCommand < DevSystem::SimpleCommand
 
     DockerShell.hello_alpine
   ensure
-    log "#{Lizarb.time_diff t} | done"
+    log "#{time_diff t} | done"
   end
 
   # liza docker:version

--- a/lib/liza/unit.rb
+++ b/lib/liza/unit.rb
@@ -476,24 +476,26 @@ Did you accidentally fall into an infinite loop?
 
       erbs = self.class.erbs_for format, keys, allow_missing: allow_missing
       erbs.to_a.reverse.each do |key, erb|
-        t_diff = time_diff time.now
         if true
+          t = Time.now
           s = erb.result binding, self
-          log_render_out "#{erb.name}.#{erb.format}", s.length, t_diff, kaller: caller if log_rendering
+          log_render_out "#{erb.name}.#{erb.format}", s.length, (time_diff t), kaller: caller if log_rendering
         end
 
         if converted and DevBox[:shell].convert? erb.format, format
+          t = Time.now
           convert_env = {format_from: erb.format, format_to: format, convert_in: s}
           DevBox.convert(convert_env)
           s = convert_env[:convert_out]
-          log_render_convert "#{erb.name}.#{format}", s.length, t_diff, kaller: caller if log_rendering
+          log_render_convert "#{erb.name}.#{format}", s.length, (time_diff t), kaller: caller if log_rendering
         end
 
         if formatted and DevBox[:shell].format? erb.format
+          t = Time.now
           format_env = {format: format, format_in: s}
           DevBox.format(format_env)
           s = format_env[:format_out]
-          log_render_format "#{erb.name}.#{format}", s.length, t_diff, kaller: caller if log_rendering
+          log_render_format "#{erb.name}.#{format}", s.length, (time_diff t), kaller: caller if log_rendering
         end
 
         render_stack.push s

--- a/lib/liza/unit.rb
+++ b/lib/liza/unit.rb
@@ -666,11 +666,8 @@ Did you accidentally fall into an infinite loop?
   #
   # Raises ArgumentError if +digits+ is not a positive Integer.
   #
-  def self.time_diff(t, digits = 4)
-    raise ArgumentError, "digits must be a positive integer" unless digits.is_a?(Integer) && digits.positive?
-    f = (Time.now.to_f - t.to_f).floor(digits)
-    u, d = f.to_s.split "."
-    "#{u}.#{d.ljust digits, "0"}"
+  def self.time_diff(t1, t2 = Time.now, digits = 4)
+    Lizarb.time_diff(t1, t2, digits)
   end
 
   ##

--- a/lib/liza/unit.rb
+++ b/lib/liza/unit.rb
@@ -476,26 +476,24 @@ Did you accidentally fall into an infinite loop?
 
       erbs = self.class.erbs_for format, keys, allow_missing: allow_missing
       erbs.to_a.reverse.each do |key, erb|
+        t_diff = Lizarb.time_diff Time.now
         if true
-          t = Time.now
           s = erb.result binding, self
-          log_render_out "#{erb.name}.#{erb.format}", s.length, t.diff, kaller: caller if log_rendering
+          log_render_out "#{erb.name}.#{erb.format}", s.length, t_diff, kaller: caller if log_rendering
         end
 
         if converted and DevBox[:shell].convert? erb.format, format
-          t = Time.now
           convert_env = {format_from: erb.format, format_to: format, convert_in: s}
           DevBox.convert(convert_env)
           s = convert_env[:convert_out]
-          log_render_convert "#{erb.name}.#{format}", s.length, t.diff, kaller: caller if log_rendering
+          log_render_convert "#{erb.name}.#{format}", s.length, t_diff, kaller: caller if log_rendering
         end
 
         if formatted and DevBox[:shell].format? erb.format
-          t = Time.now
           format_env = {format: format, format_in: s}
           DevBox.format(format_env)
           s = format_env[:format_out]
-          log_render_format "#{erb.name}.#{format}", s.length, t.diff, kaller: caller if log_rendering
+          log_render_format "#{erb.name}.#{format}", s.length, t_diff, kaller: caller if log_rendering
         end
 
         render_stack.push s

--- a/lib/liza/unit.rb
+++ b/lib/liza/unit.rb
@@ -476,7 +476,7 @@ Did you accidentally fall into an infinite loop?
 
       erbs = self.class.erbs_for format, keys, allow_missing: allow_missing
       erbs.to_a.reverse.each do |key, erb|
-        t_diff = Lizarb.time_diff Time.now
+        t_diff = time_diff time.now
         if true
           s = erb.result binding, self
           log_render_out "#{erb.name}.#{erb.format}", s.length, t_diff, kaller: caller if log_rendering

--- a/lib/lizarb.rb
+++ b/lib/lizarb.rb
@@ -124,7 +124,7 @@ module Lizarb
   module_function
 
   def log s
-    print "#{Liza::Unit.time_diff $boot_time}s " if defined? $log_boot_high
+    print "#{$boot_time.diff}s " if defined? $log_boot_high
     puts s
   end
 
@@ -958,6 +958,15 @@ module Lizarb
       @thread_ids_mutex.synchronize do
         @thread_ids.count
       end
+  end
+
+  TIME_DIFF_ERROR_MSG = "digits must be a positive integer"
+
+  def time_diff(t1, t2 = Time.now, digits = 4)
+    raise ArgumentError, TIME_DIFF_ERROR_MSG unless digits.is_a?(Integer) && digits.positive?
+    f = (t2.to_f - t1.to_f).floor(digits)
+    u, d = f.to_s.split "."
+    "#{u}.#{d.ljust digits, "0"}"
   end
 
 end

--- a/lib/lizarb.rb
+++ b/lib/lizarb.rb
@@ -124,7 +124,7 @@ module Lizarb
   module_function
 
   def log s
-    print "#{$boot_time.diff}s " if defined? $log_boot_high
+    print "#{Lizarb.time_diff $boot_time}s " if defined? $log_boot_high
     puts s
   end
 

--- a/lib/lizarb.rb
+++ b/lib/lizarb.rb
@@ -124,7 +124,7 @@ module Lizarb
   module_function
 
   def log s
-    print "#{Lizarb.time_diff $boot_time}s " if defined? $log_boot_high
+    print "#{time_diff $boot_time}s " if defined? $log_boot_high
     puts s
   end
 

--- a/lib/lizarb.rb
+++ b/lib/lizarb.rb
@@ -124,7 +124,7 @@ module Lizarb
   module_function
 
   def log s
-    print "#{$boot_time.diff}s " if defined? $log_boot_high
+    print "#{Liza::Unit.time_diff $boot_time}s " if defined? $log_boot_high
     puts s
   end
 

--- a/lib/net_system/subsystems/client/generators/client_generator.rb.controller.rb.erb
+++ b/lib/net_system/subsystems/client/generators/client_generator.rb.controller.rb.erb
@@ -17,7 +17,7 @@
     log "rss channel title: #{ hash.dig :rss, :channel, :title }"
     hash
   ensure
-    log "#{t.diff}s to request #{url}"
+    log "#{Lizarb.time_diff t}s to request #{url}"
     hash
   end
 

--- a/lib/net_system/subsystems/client/generators/client_generator.rb.controller.rb.erb
+++ b/lib/net_system/subsystems/client/generators/client_generator.rb.controller.rb.erb
@@ -17,7 +17,7 @@
     log "rss channel title: #{ hash.dig :rss, :channel, :title }"
     hash
   ensure
-    log "#{Lizarb.time_diff t}s to request #{url}"
+    log "#{time_diff t}s to request #{url}"
     hash
   end
 

--- a/lib/net_system/subsystems/database/db_clients/mongo_db_client.rb
+++ b/lib/net_system/subsystems/database/db_clients/mongo_db_client.rb
@@ -27,7 +27,7 @@ class NetSystem::MongoDbClient < NetSystem::DbClient
 
     @conn = Mongo::Client.new(uri)
   ensure
-    log "#{t.diff}s | Connecting to #{hash}"
+    log "#{Lizarb.time_diff t}s | Connecting to #{hash}"
   end
 
   attr_reader :conn
@@ -36,7 +36,7 @@ class NetSystem::MongoDbClient < NetSystem::DbClient
     t = Time.now
     raise NotImplementedError
   ensure
-    log "#{t.diff}s | #{cmd_name} | #{args}"
+    log "#{Lizarb.time_diff t}s | #{cmd_name} | #{args}"
   end
 
   def now

--- a/lib/net_system/subsystems/database/db_clients/mongo_db_client.rb
+++ b/lib/net_system/subsystems/database/db_clients/mongo_db_client.rb
@@ -27,7 +27,7 @@ class NetSystem::MongoDbClient < NetSystem::DbClient
 
     @conn = Mongo::Client.new(uri)
   ensure
-    log "#{Lizarb.time_diff t}s | Connecting to #{hash}"
+    log "#{time_diff t}s | Connecting to #{hash}"
   end
 
   attr_reader :conn
@@ -36,7 +36,7 @@ class NetSystem::MongoDbClient < NetSystem::DbClient
     t = Time.now
     raise NotImplementedError
   ensure
-    log "#{Lizarb.time_diff t}s | #{cmd_name} | #{args}"
+    log "#{time_diff t}s | #{cmd_name} | #{args}"
   end
 
   def now

--- a/lib/net_system/subsystems/database/db_clients/mysql_db_client.rb
+++ b/lib/net_system/subsystems/database/db_clients/mysql_db_client.rb
@@ -17,7 +17,7 @@ class NetSystem::MysqlDbClient < NetSystem::DbClient
 
     @conn = Mysql2::Client.new(hash)
   ensure
-    log "#{Lizarb.time_diff t}s | Connecting to #{hash}"
+    log "#{time_diff t}s | Connecting to #{hash}"
   end
 
   attr_reader :conn
@@ -28,7 +28,7 @@ class NetSystem::MysqlDbClient < NetSystem::DbClient
 
     result
   ensure
-    log "#{Lizarb.time_diff t}s | #{sql} | #{args}"
+    log "#{time_diff t}s | #{sql} | #{args}"
   end
 
   def now

--- a/lib/net_system/subsystems/database/db_clients/mysql_db_client.rb
+++ b/lib/net_system/subsystems/database/db_clients/mysql_db_client.rb
@@ -17,7 +17,7 @@ class NetSystem::MysqlDbClient < NetSystem::DbClient
 
     @conn = Mysql2::Client.new(hash)
   ensure
-    log "#{t.diff}s | Connecting to #{hash}"
+    log "#{Lizarb.time_diff t}s | Connecting to #{hash}"
   end
 
   attr_reader :conn
@@ -28,7 +28,7 @@ class NetSystem::MysqlDbClient < NetSystem::DbClient
 
     result
   ensure
-    log "#{t.diff}s | #{sql} | #{args}"
+    log "#{Lizarb.time_diff t}s | #{sql} | #{args}"
   end
 
   def now

--- a/lib/net_system/subsystems/database/db_clients/pgsql_db_client.rb
+++ b/lib/net_system/subsystems/database/db_clients/pgsql_db_client.rb
@@ -13,7 +13,7 @@ class NetSystem::PgsqlDbClient < NetSystem::DbClient
     hash = NetBox[:client].get(:pgsql_hash) if hash.empty?
     @conn = PG::Connection.new(hash)
   ensure
-    log "#{Lizarb.time_diff t}s | Connecting to #{hash}"
+    log "#{time_diff t}s | Connecting to #{hash}"
   end
 
   attr_reader :conn
@@ -24,7 +24,7 @@ class NetSystem::PgsqlDbClient < NetSystem::DbClient
 
     result
   ensure
-    log "#{Lizarb.time_diff t}s | #{sql} | #{args}"
+    log "#{time_diff t}s | #{sql} | #{args}"
   end
 
   def now

--- a/lib/net_system/subsystems/database/db_clients/pgsql_db_client.rb
+++ b/lib/net_system/subsystems/database/db_clients/pgsql_db_client.rb
@@ -13,7 +13,7 @@ class NetSystem::PgsqlDbClient < NetSystem::DbClient
     hash = NetBox[:client].get(:pgsql_hash) if hash.empty?
     @conn = PG::Connection.new(hash)
   ensure
-    log "#{t.diff}s | Connecting to #{hash}"
+    log "#{Lizarb.time_diff t}s | Connecting to #{hash}"
   end
 
   attr_reader :conn
@@ -24,7 +24,7 @@ class NetSystem::PgsqlDbClient < NetSystem::DbClient
 
     result
   ensure
-    log "#{t.diff}s | #{sql} | #{args}"
+    log "#{Lizarb.time_diff t}s | #{sql} | #{args}"
   end
 
   def now

--- a/lib/net_system/subsystems/database/db_clients/redis_db_client.rb
+++ b/lib/net_system/subsystems/database/db_clients/redis_db_client.rb
@@ -29,7 +29,7 @@ class NetSystem::RedisDbClient < NetSystem::DbClient
     end
     @conn = Redis.new(*args)
   ensure
-    log "#{t.diff}s | Connecting to #{args}"
+    log "#{Lizarb.time_diff t}s | Connecting to #{args}"
   end
 
   attr_reader :conn
@@ -40,7 +40,7 @@ class NetSystem::RedisDbClient < NetSystem::DbClient
 
     result
   ensure
-    log "#{t.diff}s | #{cmd_name} | #{args}"
+    log "#{Lizarb.time_diff t}s | #{cmd_name} | #{args}"
   end
 
   def now

--- a/lib/net_system/subsystems/database/db_clients/redis_db_client.rb
+++ b/lib/net_system/subsystems/database/db_clients/redis_db_client.rb
@@ -29,7 +29,7 @@ class NetSystem::RedisDbClient < NetSystem::DbClient
     end
     @conn = Redis.new(*args)
   ensure
-    log "#{Lizarb.time_diff t}s | Connecting to #{args}"
+    log "#{time_diff t}s | Connecting to #{args}"
   end
 
   attr_reader :conn
@@ -40,7 +40,7 @@ class NetSystem::RedisDbClient < NetSystem::DbClient
 
     result
   ensure
-    log "#{Lizarb.time_diff t}s | #{cmd_name} | #{args}"
+    log "#{time_diff t}s | #{cmd_name} | #{args}"
   end
 
   def now

--- a/lib/net_system/subsystems/database/db_clients/sqlite_db_client.rb
+++ b/lib/net_system/subsystems/database/db_clients/sqlite_db_client.rb
@@ -16,7 +16,7 @@ class NetSystem::SqliteDbClient < NetSystem::DbClient
     end
     @conn = SQLite3::Database.new(*args)
   ensure
-    log "#{t.diff}s | Connecting to #{args}"
+    log "#{Lizarb.time_diff t}s | Connecting to #{args}"
   end
 
   attr_reader :conn
@@ -27,7 +27,7 @@ class NetSystem::SqliteDbClient < NetSystem::DbClient
 
     result
   ensure
-    log "#{t.diff}s | #{sql} | #{args}"
+    log "#{Lizarb.time_diff t}s | #{sql} | #{args}"
   end
 
   def now

--- a/lib/net_system/subsystems/database/db_clients/sqlite_db_client.rb
+++ b/lib/net_system/subsystems/database/db_clients/sqlite_db_client.rb
@@ -16,7 +16,7 @@ class NetSystem::SqliteDbClient < NetSystem::DbClient
     end
     @conn = SQLite3::Database.new(*args)
   ensure
-    log "#{Lizarb.time_diff t}s | Connecting to #{args}"
+    log "#{time_diff t}s | Connecting to #{args}"
   end
 
   attr_reader :conn
@@ -27,7 +27,7 @@ class NetSystem::SqliteDbClient < NetSystem::DbClient
 
     result
   ensure
-    log "#{Lizarb.time_diff t}s | #{sql} | #{args}"
+    log "#{time_diff t}s | #{sql} | #{args}"
   end
 
   def now

--- a/lib/web_system/subsystems/rack/commands/rack_command.rb
+++ b/lib/web_system/subsystems/rack/commands/rack_command.rb
@@ -23,7 +23,7 @@ class WebSystem::RackCommand < DevSystem::SimpleCommand
 
     rack_panel.call menv
   ensure
-    log "#{ t.diff }s | server closed on port #{ port }"
+    log "#{ Lizarb.time_diff t }s | server closed on port #{ port }"
   end
 
   def rack_panel

--- a/lib/web_system/subsystems/rack/commands/rack_command.rb
+++ b/lib/web_system/subsystems/rack/commands/rack_command.rb
@@ -23,7 +23,7 @@ class WebSystem::RackCommand < DevSystem::SimpleCommand
 
     rack_panel.call menv
   ensure
-    log "#{ Lizarb.time_diff t }s | server closed on port #{ port }"
+    log "#{ time_diff t }s | server closed on port #{ port }"
   end
 
   def rack_panel

--- a/lib/web_system/subsystems/request/request_panel.rb
+++ b/lib/web_system/subsystems/request/request_panel.rb
@@ -8,7 +8,7 @@ class WebSystem::RequestPanel < Liza::Panel
     request_klass.call menv
 
     ret = [menv[:response_status], menv[:response_headers], [menv[:response_body]]]
-    log "#{ret[0]} with #{ret[2].first.size} bytes in #{Lizarb.time_diff t}s"
+    log "#{ret[0]} with #{ret[2].first.size} bytes in #{time_diff t}s"
     ret
   rescue => e
     raise e if allow_raise
@@ -16,7 +16,7 @@ class WebSystem::RequestPanel < Liza::Panel
     menv["LIZA_ERROR"] = e
 
     ret = request_klass.call menv
-    log "#{ret[0]} with #{ret[2].first.size} bytes in #{Lizarb.time_diff t}s"
+    log "#{ret[0]} with #{ret[2].first.size} bytes in #{time_diff t}s"
     puts
     ret
   end

--- a/lib/web_system/subsystems/request/request_panel.rb
+++ b/lib/web_system/subsystems/request/request_panel.rb
@@ -8,7 +8,7 @@ class WebSystem::RequestPanel < Liza::Panel
     request_klass.call menv
 
     ret = [menv[:response_status], menv[:response_headers], [menv[:response_body]]]
-    log "#{ret[0]} with #{ret[2].first.size} bytes in #{t.diff}s"
+    log "#{ret[0]} with #{ret[2].first.size} bytes in #{Lizarb.time_diff t}s"
     ret
   rescue => e
     raise e if allow_raise
@@ -16,7 +16,7 @@ class WebSystem::RequestPanel < Liza::Panel
     menv["LIZA_ERROR"] = e
 
     ret = request_klass.call menv
-    log "#{ret[0]} with #{ret[2].first.size} bytes in #{t.diff}s"
+    log "#{ret[0]} with #{ret[2].first.size} bytes in #{Lizarb.time_diff t}s"
     puts
     ret
   end


### PR DESCRIPTION
- This PR focus on migrating the use of Time::diff method to the time_diff from Liza::Unit.

Closes #88